### PR TITLE
Refactor releaseName handling in YAML configuration

### DIFF
--- a/applications/appset-ops-tools.yaml
+++ b/applications/appset-ops-tools.yaml
@@ -44,11 +44,11 @@ spec:
           {{- end }}
           helm:
             releaseName: >-
-              {{- if hasKey . "releaseName" -}}
+              {{ if hasKey . "releaseName" }}
                 {{ ternary .path.basenameNormalized .releaseName (eq .releaseName ".") }}
-              {{- else -}}
+              {{ else }}
                 {{ printf "%s-%s" (index .path.segments 1) .path.basenameNormalized }}
-              {{- end -}}
+              {{ end }}
             valueFiles:
               - $values/base/{{ printf "%s.yaml" .path.basenameNormalized }}
               - $values/{{ .path.path }}/values.yaml

--- a/applications/appset-ops-tools.yaml
+++ b/applications/appset-ops-tools.yaml
@@ -43,12 +43,7 @@ spec:
           chart: '{{ .chartName | default .path.basenameNormalized }}'
           {{- end }}
           helm:
-            releaseName: >-
-              {{ if hasKey . "releaseName" }}
-                {{ ternary .path.basenameNormalized .releaseName (eq .releaseName ".") }}
-              {{ else }}
-                {{ printf "%s-%s" (index .path.segments 1) .path.basenameNormalized }}
-              {{ end }}
+            releaseName: '{{ if hasKey . "releaseName" }}{{ if eq .releaseName "." }}{{ .path.basenameNormalized }}{{ else }}{{ .releaseName }}{{ end }}{{ else }}{{ printf "%s-%s" (index .path.segments 1) .path.basenameNormalized }}{{ end }}'
             valueFiles:
               - $values/base/{{ printf "%s.yaml" .path.basenameNormalized }}
               - $values/{{ .path.path }}/values.yaml

--- a/applications/appset-ops-tools.yaml
+++ b/applications/appset-ops-tools.yaml
@@ -43,7 +43,12 @@ spec:
           chart: '{{ .chartName | default .path.basenameNormalized }}'
           {{- end }}
           helm:
-            releaseName: '{{ .releaseName | default (printf "%s-%s" (index .path.segments 1) .path.basenameNormalized) }}'
+            releaseName: >-
+              {{- if hasKey . "releaseName" -}}
+                {{ ternary .path.basenameNormalized .releaseName (eq .releaseName ".") }}
+              {{- else -}}
+                {{ printf "%s-%s" (index .path.segments 1) .path.basenameNormalized }}
+              {{- end -}}
             valueFiles:
               - $values/base/{{ printf "%s.yaml" .path.basenameNormalized }}
               - $values/{{ .path.path }}/values.yaml

--- a/environments/sandbox-oci/local-path-provisioner/config.yaml
+++ b/environments/sandbox-oci/local-path-provisioner/config.yaml
@@ -1,5 +1,5 @@
 namespace: local-path-storage
-releaseName: local-path-provisioner
+releaseName: "."
 
 repoURL: oci://ghcr.io/rancher/local-path-provisioner/charts/local-path-provisioner
 targetRevision: 0.0.36

--- a/environments/sandbox-oci/tailscale/config.yaml
+++ b/environments/sandbox-oci/tailscale/config.yaml
@@ -1,3 +1,3 @@
 namespace: tailscale
 targetRevision: HEAD
-releaseName: tailscale
+releaseName: foo

--- a/environments/sandbox-oci/tailscale/config.yaml
+++ b/environments/sandbox-oci/tailscale/config.yaml
@@ -1,3 +1,3 @@
 namespace: tailscale
 targetRevision: HEAD
-releaseName: foo
+releaseName: tailscale


### PR DESCRIPTION
Update helm.releaseName logic to allow for simpler overriding
- if `.releaseName` = ".", use the parent directory's name
- if set to another value use that value
- if not set use the default `<cluster-name>-<app-name>`