### PR TITLE
Add OCI Object Storage backup CronJob for actual-budget

### DIFF
--- a/charts/actual-budget/Chart.yaml
+++ b/charts/actual-budget/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: actual-budget
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0"
+
+dependencies:
+  - name: actualbudget
+    repository: https://community-charts.github.io/helm-charts
+    version: 1.9.2

--- a/charts/actual-budget/templates/cronjob-backup.yaml
+++ b/charts/actual-budget/templates/cronjob-backup.yaml
@@ -1,0 +1,53 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: actualbudget-backup
+spec:
+  schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+            - name: tar-data
+              image: {{ .Values.backup.busyboxImage }}
+              command:
+                - sh
+                - -c
+                - tar -czf /backup/actualbudget-backup.tar.gz -C /data .
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                  readOnly: true
+                - name: backup
+                  mountPath: /backup
+          containers:
+            - name: upload
+              image: {{ .Values.backup.ociCliImage }}
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  NAMESPACE=$(oci os ns get --auth instance_principal --region {{ .Values.backup.region }} --query data --raw-output)
+                  oci os object put --auth instance_principal --region {{ .Values.backup.region }} \
+                    --namespace "$NAMESPACE" \
+                    --bucket-name {{ .Values.backup.bucket }} \
+                    --name {{ .Values.backup.objectName }} \
+                    --file /backup/actualbudget-backup.tar.gz \
+                    --force
+              volumeMounts:
+                - name: backup
+                  mountPath: /backup
+                  readOnly: true
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: {{ .Release.Name }}-data
+            - name: backup
+              emptyDir: {}

--- a/charts/actual-budget/values.yaml
+++ b/charts/actual-budget/values.yaml
@@ -1,0 +1,14 @@
+actualbudget:
+  image:
+    repository: docker.io/actualbudget/actual-server
+  persistence:
+    enabled: true
+    size: 4Gi
+
+backup:
+  schedule: "0 3 */3 * *"
+  bucket: benkonicek-backups-us-ashburn-1
+  region: us-ashburn-1
+  objectName: actual-budget/actualbudget-backup.tar.gz
+  ociCliImage: ghcr.io/oracle/oci-cli:20260805
+  busyboxImage: busybox:1.37

--- a/environments/sandbox-oci/actual-budget/config.yaml
+++ b/environments/sandbox-oci/actual-budget/config.yaml
@@ -1,7 +1,5 @@
 namespace: actual
-repoURL: https://community-charts.github.io/helm-charts
-targetRevision: 1.9.2
-chartName: actualbudget
+targetRevision: HEAD
 releaseName: actualbudget
 
 serverSideApply: true

--- a/environments/sandbox-oci/actual-budget/values.yaml
+++ b/environments/sandbox-oci/actual-budget/values.yaml
@@ -1,2 +1,0 @@
-image:
-  repository: docker.io/actualbudget/actual-server


### PR DESCRIPTION
## Summary
- Wraps `actualbudget` in a local chart (`charts/actual-budget/`, same pattern as `charts/pihole`) so a custom CronJob can be attached, since the upstream chart doesn't support extra pods/cronjobs via values.
- Enables a 4Gi PVC (`local-path-provisioner`, the cluster's default StorageClass) — previously `/data` was an `emptyDir`, so all budget data was already lost on every pod restart. This is a prerequisite for backups to mean anything.
- Adds a `CronJob` that runs every 3 days: a `busybox` init container tars `/data`, then a `ghcr.io/oracle/oci-cli` container uploads it to the `benkonicek-backups-us-ashburn-1` bucket under a fixed object name, authenticating via credential-less instance-principal auth (OKE node dynamic group permissions) — no secrets involved. Retention is handled by the bucket's existing versioning + 30-day lifecycle policy, so the job just overwrites in place.
- Points `environments/sandbox-oci/actual-budget/config.yaml` at the new local chart instead of the upstream Helm repo directly, keeping `releaseName: actualbudget` so no existing resources get renamed/recreated.

## Test plan
- [x] `helm dependency update charts/actual-budget` succeeds
- [x] `helm template charts/actual-budget -f charts/actual-budget/values.yaml` renders cleanly — confirmed Deployment's `/data` volume is now `persistentVolumeClaim: actualbudget-data` (not `emptyDir`), the PVC renders at 4Gi, and the `CronJob/actualbudget-backup` renders with the expected schedule/image/args
- [x] `helm lint charts/actual-budget` passes
- [x] Review the ArgoCD diff posted by the PR-preview workflow to confirm only the intended resources change (new PVC, updated Deployment volume, new CronJob)
- [ ] After merge/sync, manually trigger the CronJob once (`kubectl create job --from=cronjob/actualbudget-backup -n actual manual-test`) and confirm an object lands at `benkonicek-backups-us-ashburn-1/actual-budget/actualbudget-backup.tar.gz`

🤖 Generated with [Claude Code](https://claude.com/claude-code)