### PR TITLE
Add permanently-suspended restore CronJob for actual-budget

### DIFF
--- a/charts/actual-budget/templates/cronjob-restore.yaml
+++ b/charts/actual-budget/templates/cronjob-restore.yaml
@@ -1,0 +1,59 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: actualbudget-restore
+spec:
+  # Never runs on a schedule -- suspend: true keeps this permanently inert. Trigger a restore
+  # manually with:
+  #   kubectl create job --from=cronjob/actualbudget-restore -n {{ .Release.Namespace }} manual-restore
+  # Scale the actualbudget Deployment to 0 replicas first so the restore doesn't race with the
+  # running server writing to the same volume. This replaces the entire contents of /data.
+  schedule: "0 0 * * *"
+  suspend: true
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: Never
+          initContainers:
+            - name: download
+              image: {{ .Values.backup.ociCliImage }}
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  NAMESPACE=$(oci os ns get --auth instance_principal --region {{ .Values.backup.region }} --query data --raw-output)
+                  oci os object get --auth instance_principal --region {{ .Values.backup.region }} \
+                    --namespace "$NAMESPACE" \
+                    --bucket-name {{ .Values.backup.bucket }} \
+                    --name {{ .Values.backup.objectName }} \
+                    --file /restore/actualbudget-backup.tar.gz
+              volumeMounts:
+                - name: restore
+                  mountPath: /restore
+          containers:
+            - name: extract
+              image: {{ .Values.backup.busyboxImage }}
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  rm -rf /data/*
+                  tar -xzf /restore/actualbudget-backup.tar.gz -C /data
+              volumeMounts:
+                - name: data
+                  mountPath: /data
+                - name: restore
+                  mountPath: /restore
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: {{ .Release.Name }}-data
+            - name: restore
+              emptyDir: {}


### PR DESCRIPTION
## Summary
- Adds `actualbudget-restore`, a `CronJob` with `suspend: true` so it never fires on a schedule — it exists purely to be triggered manually via `kubectl create job --from=cronjob/actualbudget-restore -n actual manual-restore`.
- Downloads the current backup object from `benkonicek-backups-us-ashburn-1` and extracts it over `/data`, wiping existing contents first for a clean restore rather than a merge.
- Intended for recovering from a lost/empty PV — e.g. if the node backing the `local-path-provisioner` volume is replaced and the PVC has to be recreated from scratch. **Scale the actualbudget Deployment to 0 first** before triggering, so the restore doesn't race with the live server writing to the same volume (documented directly in the CronJob's spec comment).
- Reuses the same `backup.*` values (bucket/region/objectName/images) as the backup CronJob from #320/#322 — no new values added.

## Test plan
- [x] `helm lint charts/actual-budget` passes
- [x] `helm template ... --show-only templates/cronjob-restore.yaml` renders correctly, including the resolved namespace in the trigger-command comment
- [ ] Review the PR-preview workflow's ArgoCD diff to confirm only the new CronJob is added
- [ ] After sync, do a real dry run: scale actualbudget to 0, trigger the restore Job, confirm `/data` is repopulated from the bucket, then scale back up

🤖 Generated with [Claude Code](https://claude.com/claude-code)