### PR TITLE
Add actual-budget backup/restore runbook

### DIFF
--- a/docs/runbooks/actual-budget.md
+++ b/docs/runbooks/actual-budget.md
@@ -81,7 +81,9 @@ fresh (empty) PV gets provisioned on whichever node the pod actually lands on. A
 follow the [Restore](#restore) steps above to repopulate it from the latest backup — today this
 is a manual step you have to remember to do.
 
-## Future work: auto-restore on pod startup
+## Future work
+
+### Auto-restore on pod startup
 
 Planned improvement (not yet implemented): add an `initContainer` to the actualbudget
 `Deployment` itself (the upstream chart already exposes `initContainers: []` as a values hook)
@@ -101,3 +103,19 @@ already defaults to not evicting pods with local-path PVCs (so this only happens
 events, not routine autoscaler churn), and a real watch-loop controller (plus RBAC) is a lot of
 surface area for something this infrequent and already a single manual `kubectl delete pvc` away
 from fixed.
+
+### Alerting on pod pending/unavailable
+
+Planned improvement (not yet implemented): right now, discovering the stuck-`Pending` state
+described above relies on someone noticing (e.g. opening the app and finding it down). Add a
+`PrometheusRule` — `prometheus-operator` (`kube-prometheus-stack`) is already deployed cluster-wide
+— that fires when the actualbudget `Deployment` has zero available replicas for longer than a
+few minutes, so a lost/replaced node surfaces as an alert instead of silence.
+
+Two things to confirm/resolve as part of that work:
+- `kube-prometheus-stack`'s bundled default rules (`KubePodNotReady`,
+  `KubeDeploymentReplicasMismatch`, etc.) may already cover this generically — check whether one
+  of those already fires for this pod before adding a dedicated rule.
+- There's no Alertmanager receiver configured in this repo yet (no Slack/email/etc. route), so an
+  alert would currently only be visible in the Alertmanager/Grafana UI, not actively pushed
+  anywhere. Detection without a notification channel doesn't fully close the gap.

--- a/docs/runbooks/actual-budget.md
+++ b/docs/runbooks/actual-budget.md
@@ -1,0 +1,110 @@
+# Actual Budget: Backup & Restore Runbook
+
+Actual Budget is deployed via [`charts/actual-budget`](../../charts/actual-budget), a local
+wrapper chart around the upstream `actualbudget` chart (see
+[`environments/sandbox-oci/actual-budget`](../../environments/sandbox-oci/actual-budget) for the
+ArgoCD config). This document covers how backups work, how to restore, and what to do if the
+node holding its storage disappears.
+
+## Storage
+
+`/data` is a 4Gi PVC (`actualbudget-data`) provisioned by `local-path-provisioner` — the
+cluster's default StorageClass. This means the data lives on a specific node's local disk, is
+**not replicated**, and the PV's `nodeAffinity` is pinned to that node. See
+[Recovering from a lost or replaced node](#recovering-from-a-lost-or-replaced-node) below for
+what that implies.
+
+## Backup
+
+[`templates/cronjob-backup.yaml`](../../charts/actual-budget/templates/cronjob-backup.yaml) runs
+every 3 days (`backup.schedule` in [`values.yaml`](../../charts/actual-budget/values.yaml)):
+
+1. A `busybox` init container tars `/data`, but first checks that `/data/user-files` is
+   non-empty. If it's empty (data volume looks uninitialized — e.g. right after a node
+   replacement recreated the PV from scratch), it exits non-zero and the Job fails loudly
+   instead of uploading a near-empty archive. (`account.sqlite` was deliberately **not** used
+   for this check — `actual-server` creates it lazily on the first request that touches account
+   state, so it exists within seconds of a fresh empty volume, before any real budget data does.)
+2. An `oci-cli` container (`ghcr.io/oracle/oci-cli`, credential-less via
+   `--auth instance_principal`, using the OKE nodes' dynamic-group IAM permissions) uploads the
+   tarball to `benkonicek-backups-us-ashburn-1` under a **fixed object name**
+   (`actual-budget/actualbudget-backup.tar.gz`), overwriting the previous backup each run.
+
+Retention is handled entirely on the OCI side: the bucket has versioning enabled with a 30-day
+lifecycle policy on old versions, so there's no pruning logic in the CronJob itself.
+
+Auth is set up in [`terraform/oci/sandbox/iam.tf`](https://github.com/bkonicek/terraform) — the
+`oke-dyn-group-all` dynamic group matches nodes via a custom defined tag (`oke.node=true`,
+applied to the node pool's `node_config_details`), and the `oke-backups-bucket-access` policy
+grants it `manage objects` (not `use` — `OBJECT_CREATE`, needed the first time an object name is
+written, is only granted at the `manage` tier) scoped to that one bucket.
+
+To check backup history:
+
+```
+kubectl get jobs -n actual -l job-name --sort-by=.metadata.creationTimestamp | grep actualbudget-backup
+kubectl logs -n actual job/<job-name>
+```
+
+## Restore
+
+[`templates/cronjob-restore.yaml`](../../charts/actual-budget/templates/cronjob-restore.yaml)
+defines `actualbudget-restore`, a `CronJob` with `suspend: true` — it never runs on its own. It
+downloads the current backup object and extracts it over `/data`, **wiping existing contents
+first** (clean restore, not a merge).
+
+To restore:
+
+```
+# 1. Stop the app so it isn't writing to /data during the restore
+kubectl scale deployment actualbudget -n actual --replicas=0
+
+# 2. Trigger the restore Job
+kubectl create job --from=cronjob/actualbudget-restore -n actual manual-restore
+
+# 3. Watch it finish
+kubectl logs -n actual job/manual-restore -f
+
+# 4. Bring the app back up
+kubectl scale deployment actualbudget -n actual --replicas=1
+```
+
+## Recovering from a lost or replaced node
+
+Because storage is node-pinned (see [Storage](#storage) above), if the node backing
+`actualbudget-data` is deleted (node pool cycling, manual replacement, hardware failure), the
+PV's `nodeAffinity` points at a node that no longer exists. The PVC stays `Bound` — Kubernetes
+does not detect or heal this on its own — so the actualbudget pod sits `Pending` indefinitely
+(`0/N nodes are available: node(s) didn't match Pod's node affinity`).
+
+Recovery is a single manual step, since the default StorageClass uses `reclaimPolicy: Delete`:
+
+```
+kubectl delete pvc actualbudget-data -n actual
+```
+
+ArgoCD's `selfHeal: true` sync policy then recreates the PVC from the chart automatically, and a
+fresh (empty) PV gets provisioned on whichever node the pod actually lands on. At that point,
+follow the [Restore](#restore) steps above to repopulate it from the latest backup — today this
+is a manual step you have to remember to do.
+
+## Future work: auto-restore on pod startup
+
+Planned improvement (not yet implemented): add an `initContainer` to the actualbudget
+`Deployment` itself (the upstream chart already exposes `initContainers: []` as a values hook)
+that runs the same "is `/data/user-files` empty?" check used by the backup guard, inverted — if
+empty, it automatically downloads and extracts the latest backup *before* the app container
+starts.
+
+This would close the gap in the recovery flow above: after `kubectl delete pvc`, the pod would
+restore itself on boot instead of starting with an empty database and waiting on a human to
+notice and trigger the restore Job. The `actualbudget-restore` CronJob would remain useful as a
+manual-override tool (e.g. restoring to recover from in-app data corruption, not just node loss),
+but would no longer be the primary recovery path.
+
+Deliberately **not** planned: an automated controller to detect the stuck-`Pending` state and
+delete the stale PVC itself. Kubernetes has no built-in primitive for this, cluster-autoscaler
+already defaults to not evicting pods with local-path PVCs (so this only happens on deliberate
+events, not routine autoscaler churn), and a real watch-loop controller (plus RBAC) is a lot of
+surface area for something this infrequent and already a single manual `kubectl delete pvc` away
+from fixed.

--- a/docs/runbooks/actual-budget.md
+++ b/docs/runbooks/actual-budget.md
@@ -25,19 +25,12 @@ every 3 days (`backup.schedule` in [`values.yaml`](../../charts/actual-budget/va
    instead of uploading a near-empty archive. (`account.sqlite` was deliberately **not** used
    for this check — `actual-server` creates it lazily on the first request that touches account
    state, so it exists within seconds of a fresh empty volume, before any real budget data does.)
-2. An `oci-cli` container (`ghcr.io/oracle/oci-cli`, credential-less via
-   `--auth instance_principal`, using the OKE nodes' dynamic-group IAM permissions) uploads the
-   tarball to `benkonicek-backups-us-ashburn-1` under a **fixed object name**
+2. An `oci-cli` container (`ghcr.io/oracle/oci-cli`) uploads the tarball to
+   `benkonicek-backups-us-ashburn-1` under a **fixed object name**
    (`actual-budget/actualbudget-backup.tar.gz`), overwriting the previous backup each run.
 
 Retention is handled entirely on the OCI side: the bucket has versioning enabled with a 30-day
 lifecycle policy on old versions, so there's no pruning logic in the CronJob itself.
-
-Auth is set up in [`terraform/oci/sandbox/iam.tf`](https://github.com/bkonicek/terraform) — the
-`oke-dyn-group-all` dynamic group matches nodes via a custom defined tag (`oke.node=true`,
-applied to the node pool's `node_config_details`), and the `oke-backups-bucket-access` policy
-grants it `manage objects` (not `use` — `OBJECT_CREATE`, needed the first time an object name is
-written, is only granted at the `manage` tier) scoped to that one bucket.
 
 To check backup history:
 


### PR DESCRIPTION
## Summary
- New `docs/runbooks/` folder, starting with `actual-budget.md`.
- Documents how the backup CronJob works (schedule, empty-volume guard, retention via bucket versioning), how to manually trigger a restore, and the exact recovery steps if the node backing the local-path PV is lost or replaced (`kubectl delete pvc` → ArgoCD selfHeal → restore).
- Captures the planned-but-not-yet-built auto-restore `initContainer` (checks `/data/user-files` on pod start, restores automatically if empty) and explicitly notes what's *not* planned (an automated controller to detect/clear the stuck PVC) and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)