### PR TITLE
Fix Slack notification text for Alertmanager alerts

### DIFF
--- a/charts/prometheus-operator/templates/alertmanagerconfig-slack.yaml
+++ b/charts/prometheus-operator/templates/alertmanagerconfig-slack.yaml
@@ -1,11 +1,3 @@
-{{/*
-Alertmanager evaluates {{ }} in slackConfigs.text/title itself, at notification
-time, using its own Go templates (Annotations/Labels per alert) - not Helm.
-Since this file is also a Helm template, any such syntax written literally
-would get evaluated (or error) at `helm template` time instead. Backtick
-raw-string it into a variable so Helm treats it as an opaque string and only
-Alertmanager ever parses the {{ }} inside it.
-*/}}
 {{- $slackText := `{{ range .Alerts }}
 *Summary:* {{ .Annotations.summary }}
 *Description:* {{ .Annotations.description }}

--- a/charts/prometheus-operator/templates/alertmanagerconfig-slack.yaml
+++ b/charts/prometheus-operator/templates/alertmanagerconfig-slack.yaml
@@ -1,3 +1,17 @@
+{{/*
+Alertmanager evaluates {{ }} in slackConfigs.text/title itself, at notification
+time, using its own Go templates (Annotations/Labels per alert) - not Helm.
+Since this file is also a Helm template, any such syntax written literally
+would get evaluated (or error) at `helm template` time instead. Backtick
+raw-string it into a variable so Helm treats it as an opaque string and only
+Alertmanager ever parses the {{ }} inside it.
+*/}}
+{{- $slackText := `{{ range .Alerts }}
+*Summary:* {{ .Annotations.summary }}
+*Description:* {{ .Annotations.description }}
+*Severity:* {{ .Labels.severity }}
+{{ if .Annotations.runbook_url }}*Runbook:* {{ .Annotations.runbook_url }}
+{{ end }}{{ end }}` -}}
 apiVersion: monitoring.coreos.com/v1alpha1
 kind: AlertmanagerConfig
 metadata:
@@ -25,6 +39,7 @@ spec:
       slackConfigs:
         - channel: {{ .Values.alerting.slack.channel | quote }}
           sendResolved: true
+          text: {{ $slackText | quote }}
           apiURL:
             name: {{ .Values.alerting.slack.secretName | quote }}
             key: {{ .Values.alerting.slack.secretKey | quote }}


### PR DESCRIPTION
## Summary
Follow-up to #325. After that merged, a live `KubeJobFailed` alert confirmed the Slack pipeline works end-to-end, but the message only showed Alertmanager's built-in default title (`[FIRING:2] KubeJobFailed actual (...)`) — no summary/description/runbook link. Alertmanager's built-in default *text* template is empty, so those annotations never rendered regardless of what the `PrometheusRule` sets.

- Add an explicit `text` template to the Slack receiver in `charts/prometheus-operator/templates/alertmanagerconfig-slack.yaml`, pulling `summary`/`description`/`severity`/`runbook_url` from each alert's annotations/labels.

## Test plan
- [x] `helm template charts/prometheus-operator -f environments/sandbox-oci/prometheus-operator/values.yaml` — renders cleanly, the Alertmanager-side `{{ }}` template text survives Helm's render intact
- [ ] After merge + ArgoCD sync: confirm the next firing alert's Slack message includes the summary/description/runbook_url body

🤖 Generated with [Claude Code](https://claude.com/claude-code)