### PR TITLE
Auto-restore actualbudget from backup on empty-volume startup

### DIFF
--- a/charts/actual-budget/values.yaml
+++ b/charts/actual-budget/values.yaml
@@ -1,17 +1,85 @@
+backup:
+  schedule: "0 3 */3 * *"
+  bucket: &backupBucket benkonicek-backups-us-ashburn-1
+  region: &backupRegion us-ashburn-1
+  objectName: &backupObjectName actual-budget/actualbudget-backup.tar.gz
+  ociCliImage: &ociCliImage ghcr.io/oracle/oci-cli:20260805
+  busyboxImage: &busyboxImage busybox:1.38
+
 actualbudget:
   image:
     repository: docker.io/actualbudget/actual-server
   persistence:
     enabled: true
     size: 4Gi
-
-backup:
-  schedule: "0 3 */3 * *"
-  bucket: benkonicek-backups-us-ashburn-1
-  region: us-ashburn-1
-  objectName: actual-budget/actualbudget-backup.tar.gz
-  ociCliImage: ghcr.io/oracle/oci-cli:20260805
-  busyboxImage: busybox:1.38
+  # Runs before the app container on every pod start. Each initContainer independently
+  # re-checks whether /data/user-files is empty, so this is a no-op on a normal restart
+  # and only kicks in right after a fresh/empty PVC (e.g. a lost/replaced node) - closing
+  # the gap where the app would otherwise auto-create a blank default budget and someone
+  # has to notice and manually run the restore Job. See docs/runbooks/actual-budget.md.
+  initContainers:
+    - name: download-backup-if-empty
+      image: *ociCliImage
+      env:
+        - name: REGION
+          value: *backupRegion
+        - name: BUCKET
+          value: *backupBucket
+        - name: OBJECT_NAME
+          value: *backupObjectName
+      command:
+        - sh
+        - -c
+        - |
+          set -eu
+          if [ -n "$(ls -A /data/user-files 2>/dev/null)" ]; then
+            echo "/data/user-files is non-empty, skipping auto-restore download"
+            exit 0
+          fi
+          NAMESPACE=$(oci os ns get --auth instance_principal --region "$REGION" --query data --raw-output)
+          if ! oci os object head --auth instance_principal --region "$REGION" \
+              --namespace "$NAMESPACE" --bucket-name "$BUCKET" --name "$OBJECT_NAME" >/dev/null 2>&1; then
+            echo "No existing backup object found, starting fresh instead of auto-restoring"
+            exit 0
+          fi
+          echo "/data/user-files is empty, downloading latest backup for auto-restore"
+          oci os object get --auth instance_principal --region "$REGION" \
+            --namespace "$NAMESPACE" --bucket-name "$BUCKET" --name "$OBJECT_NAME" \
+            --file /restore/actualbudget-backup.tar.gz
+          echo "Backup downloaded for auto-restore"
+      volumeMounts:
+        - name: data
+          mountPath: /data
+          readOnly: true
+        - name: restore
+          mountPath: /restore
+    - name: extract-backup-if-empty
+      image: *busyboxImage
+      command:
+        - sh
+        - -c
+        - |
+          set -eu
+          if [ -n "$(ls -A /data/user-files 2>/dev/null)" ]; then
+            echo "/data/user-files is non-empty, skipping auto-restore extract"
+            exit 0
+          fi
+          if [ ! -f /restore/actualbudget-backup.tar.gz ]; then
+            echo "No backup archive downloaded, leaving /data empty for a fresh start"
+            exit 0
+          fi
+          rm -rf /data/*
+          tar -xzf /restore/actualbudget-backup.tar.gz -C /data
+          echo "Auto-restored actualbudget data to /data on startup"
+      volumeMounts:
+        - name: data
+          mountPath: /data
+        - name: restore
+          mountPath: /restore
+          readOnly: true
+  volumes:
+    - name: restore
+      emptyDir: {}
 
 alerting:
   enabled: true

--- a/docs/runbooks/actual-budget.md
+++ b/docs/runbooks/actual-budget.md
@@ -77,25 +77,39 @@ kubectl delete pvc actualbudget-data -n actual
 ```
 
 ArgoCD's `selfHeal: true` sync policy then recreates the PVC from the chart automatically, and a
-fresh (empty) PV gets provisioned on whichever node the pod actually lands on. At that point,
-follow the [Restore](#restore) steps above to repopulate it from the latest backup — today this
-is a manual step you have to remember to do.
-
-## Future work
+fresh (empty) PV gets provisioned on whichever node the pod actually lands on. The actualbudget
+pod then auto-restores itself from the latest backup on startup (see
+[Auto-restore on pod startup](#auto-restore-on-pod-startup) below) — no manual restore step
+needed for this specific case anymore.
 
 ### Auto-restore on pod startup
 
-Planned improvement (not yet implemented): add an `initContainer` to the actualbudget
-`Deployment` itself (the upstream chart already exposes `initContainers: []` as a values hook)
-that runs the same "is `/data/user-files` empty?" check used by the backup guard, inverted — if
-empty, it automatically downloads and extracts the latest backup *before* the app container
-starts.
+Implemented: two `initContainers` on the actualbudget `Deployment`
+([`charts/actual-budget/values.yaml`](../../charts/actual-budget/values.yaml), via the upstream
+chart's `initContainers`/`volumes` values hooks) run the same "is `/data/user-files` empty?" check
+used by the backup guard, inverted — each independently re-checks the condition and no-ops on a
+normal restart, but if `/data` is genuinely empty (e.g. right after the `kubectl delete pvc` step
+above), the first downloads the latest backup from OCI Object Storage and the second extracts it
+over `/data` *before* the app container starts. If no backup object exists yet (e.g. a brand new
+deploy that's never been backed up), it logs that and leaves the volume empty for a fresh start
+rather than failing pod startup.
 
-This would close the gap in the recovery flow above: after `kubectl delete pvc`, the pod would
-restore itself on boot instead of starting with an empty database and waiting on a human to
-notice and trigger the restore Job. The `actualbudget-restore` CronJob would remain useful as a
-manual-override tool (e.g. restoring to recover from in-app data corruption, not just node loss),
-but would no longer be the primary recovery path.
+This closes the gap that used to exist here: after `kubectl delete pvc`, the pod now restores
+itself on boot instead of starting with an empty database and waiting on a human to notice and
+trigger the restore Job. The `actualbudget-restore` CronJob remains useful as a manual-override
+tool (e.g. restoring to recover from in-app data corruption, not just node loss), but is no longer
+the primary recovery path.
+
+One caveat found while testing this against a real node cycle: if the app container ever starts
+against an empty volume *before* a restore completes (e.g. during earlier manual testing, prior to
+this auto-restore existing), Actual Budget auto-creates a default "My Finances" budget and caches
+it locally in any browser that connects during that window. A later restore replaces the
+server-side data but doesn't clean up that stale browser-local reference, so it can appear
+alongside the real restored budget in the Files list. It's cosmetic (not server-side duplicate
+data) and safe to remove via the file's `⋮` menu in the UI, or avoided entirely by not connecting
+a client during the empty-volume window — which the auto-restore above eliminates going forward.
+
+## Future work
 
 Deliberately **not** planned: an automated controller to detect the stuck-`Pending` state and
 delete the stale PVC itself. Kubernetes has no built-in primitive for this, cluster-autoscaler

--- a/docs/runbooks/actual-budget.md
+++ b/docs/runbooks/actual-budget.md
@@ -68,7 +68,13 @@ Because storage is node-pinned (see [Storage](#storage) above), if the node back
 `actualbudget-data` is deleted (node pool cycling, manual replacement, hardware failure), the
 PV's `nodeAffinity` points at a node that no longer exists. The PVC stays `Bound` — Kubernetes
 does not detect or heal this on its own — so the actualbudget pod sits `Pending` indefinitely
-(`0/N nodes are available: node(s) didn't match Pod's node affinity`).
+(`0/N nodes are available: node(s) didn't match Pod's node affinity`). You'll know this is
+happening because
+[`charts/actual-budget/templates/prometheusrule.yaml`](../../charts/actual-budget/templates/prometheusrule.yaml)
+fires `ActualBudgetDeploymentUnavailable` once the Deployment has had zero available replicas for
+more than `alerting.unavailableFor` (default `5m`), surfacing as a Slack message in `#alerts`
+instead of relying on someone noticing the app is down — see
+[`docs/runbooks/alerting.md`](alerting.md) for how that routing works.
 
 Recovery is a single manual step, since the default StorageClass uses `reclaimPolicy: Delete`:
 
@@ -77,37 +83,27 @@ kubectl delete pvc actualbudget-data -n actual
 ```
 
 ArgoCD's `selfHeal: true` sync policy then recreates the PVC from the chart automatically, and a
-fresh (empty) PV gets provisioned on whichever node the pod actually lands on. The actualbudget
-pod then auto-restores itself from the latest backup on startup (see
-[Auto-restore on pod startup](#auto-restore-on-pod-startup) below) — no manual restore step
-needed for this specific case anymore.
-
-### Auto-restore on pod startup
-
-Implemented: two `initContainers` on the actualbudget `Deployment`
+fresh (empty) PV gets provisioned on whichever node the pod actually lands on. From there, the pod
+restores itself automatically: two `initContainers` on the actualbudget `Deployment`
 ([`charts/actual-budget/values.yaml`](../../charts/actual-budget/values.yaml), via the upstream
 chart's `initContainers`/`volumes` values hooks) run the same "is `/data/user-files` empty?" check
 used by the backup guard, inverted — each independently re-checks the condition and no-ops on a
-normal restart, but if `/data` is genuinely empty (e.g. right after the `kubectl delete pvc` step
-above), the first downloads the latest backup from OCI Object Storage and the second extracts it
-over `/data` *before* the app container starts. If no backup object exists yet (e.g. a brand new
-deploy that's never been backed up), it logs that and leaves the volume empty for a fresh start
-rather than failing pod startup.
-
-This closes the gap that used to exist here: after `kubectl delete pvc`, the pod now restores
-itself on boot instead of starting with an empty database and waiting on a human to notice and
-trigger the restore Job. The `actualbudget-restore` CronJob remains useful as a manual-override
-tool (e.g. restoring to recover from in-app data corruption, not just node loss), but is no longer
-the primary recovery path.
+normal restart, but since `/data` is genuinely empty here, the first downloads the latest backup
+from OCI Object Storage and the second extracts it over `/data` *before* the app container starts.
+No manual restore trigger needed for this case — the `actualbudget-restore` CronJob remains
+available as a manual-override tool (e.g. restoring to recover from in-app data corruption, not
+just node loss), but is no longer the primary recovery path. If no backup object exists yet (e.g.
+a brand new deploy that's never been backed up), the initContainers log that and leave the volume
+empty for a fresh start rather than failing pod startup.
 
 One caveat found while testing this against a real node cycle: if the app container ever starts
-against an empty volume *before* a restore completes (e.g. during earlier manual testing, prior to
-this auto-restore existing), Actual Budget auto-creates a default "My Finances" budget and caches
-it locally in any browser that connects during that window. A later restore replaces the
-server-side data but doesn't clean up that stale browser-local reference, so it can appear
-alongside the real restored budget in the Files list. It's cosmetic (not server-side duplicate
-data) and safe to remove via the file's `⋮` menu in the UI, or avoided entirely by not connecting
-a client during the empty-volume window — which the auto-restore above eliminates going forward.
+against an empty volume *before* a restore completes (e.g. during manual testing, or before this
+auto-restore existed), Actual Budget auto-creates a default "My Finances" budget and caches it
+locally in any browser that connects during that window. A later restore replaces the server-side
+data but doesn't clean up that stale browser-local reference, so it can appear alongside the real
+restored budget in the Files list. It's cosmetic (not server-side duplicate data) and safe to
+remove via the file's `⋮` menu in the UI — and avoided going forward since the auto-restore above
+means the app never actually runs against an empty volume that a client could connect to first.
 
 ## Future work
 
@@ -117,12 +113,3 @@ already defaults to not evicting pods with local-path PVCs (so this only happens
 events, not routine autoscaler churn), and a real watch-loop controller (plus RBAC) is a lot of
 surface area for something this infrequent and already a single manual `kubectl delete pvc` away
 from fixed.
-
-### Alerting on pod pending/unavailable
-
-Implemented: [`charts/actual-budget/templates/prometheusrule.yaml`](../../charts/actual-budget/templates/prometheusrule.yaml)
-fires `ActualBudgetDeploymentUnavailable` when the actualbudget `Deployment` has had zero
-available replicas for more than `alerting.unavailableFor` (default `5m`), so a lost/replaced node
-surfaces as a Slack message in `#alerts` instead of relying on someone noticing the app is down.
-See [`docs/runbooks/alerting.md`](alerting.md) for how the Slack routing and the PrometheusRule
-convention work, and for the pattern to follow when adding alerts for other apps.


### PR DESCRIPTION
## Summary
Implements the "Auto-restore on pod startup" future-work item from `docs/runbooks/actual-budget.md`, validated against a real node-cycle test (see discussion on #325/#326).

- Two `initContainers` on the actualbudget Deployment (`download-backup-if-empty`, `extract-backup-if-empty`), added via the upstream `actualbudget` chart's `initContainers`/`volumes` values hooks in `charts/actual-budget/values.yaml`.
- Each independently re-checks whether `/data/user-files` is empty before acting, so it's a no-op on every normal restart/rollout and only kicks in right after a genuinely empty PVC (e.g. following the documented `kubectl delete pvc` recovery step).
- Gracefully skips (rather than failing pod startup) if no backup object exists yet in OCI, e.g. on a brand new deploy.
- Bucket/region/object name/image values are shared with the existing backup/restore CronJobs via YAML anchors (not Helm templating - values.yaml isn't templated, and the upstream chart's `initContainers` hook only accepts static values), so there's no duplicated config to drift.
- Updates `docs/runbooks/actual-budget.md`'s recovery flow to reflect this, and documents a cosmetic stale-browser-cache side effect discovered while testing the node-cycle scenario live.

## Test plan
- [x] `helm template`/`helm lint charts/actual-budget` - renders cleanly, initContainers correctly bind to the existing `data` PVC volume and a new `restore` emptyDir
- [x] Validated live against a real node cycle: pod stuck `Pending` on stale node affinity -> `kubectl delete pvc` -> PVC/PV recreated -> (prior to this change) pod started with an empty budget and required a manual restore trigger
- [ ] After merge + ArgoCD sync: repeat the node-cycle test and confirm the pod restores itself on startup with no manual restore step

🤖 Generated with [Claude Code](https://claude.com/claude-code)